### PR TITLE
fix: pytest --ruff and --ruff-format don't work at the command line

### DIFF
--- a/pytest_ruff.py
+++ b/pytest_ruff.py
@@ -61,18 +61,20 @@ class RuffFile(pytest.File):
         ]
 
 
-def check_file(path):
+def check_file(self, path):
     ruff = find_ruff_bin()
-    command = [ruff, "check", path, '--quiet', '--show-source', 'force-exclude']
+    command = [ruff, "check", path, '--quiet', '--show-source', '--force-exclude']
     child = Popen(command, stdout=PIPE, stderr=PIPE)
     stdout, _ = child.communicate()
     if stdout:
         raise RuffError(stdout.decode())
 
 
-def format_file(path):
+def format_file(self, path):
     ruff = find_ruff_bin()
     command = [ruff, "format", path, '--quiet', '--check', '--force-exclude']
+    import sys
+    print(command, file=sys.stderr)
     with Popen(command) as child:
         pass
 
@@ -95,7 +97,7 @@ class RuffItem(pytest.Item):
             pytest.skip("file previously passed ruff checks")
 
     def runtest(self):
-        self.handler(self.fspath)
+        self.handler(path=self.fspath)
 
         ruffmtimes = self.config.stash.get(_MTIMES_STASH_KEY, None)
         if ruffmtimes:

--- a/pytest_ruff.py
+++ b/pytest_ruff.py
@@ -73,8 +73,6 @@ def check_file(self, path):
 def format_file(self, path):
     ruff = find_ruff_bin()
     command = [ruff, "format", path, '--quiet', '--check', '--force-exclude']
-    import sys
-    print(command, file=sys.stderr)
     with Popen(command) as child:
         pass
 

--- a/pytest_ruff.py
+++ b/pytest_ruff.py
@@ -1,4 +1,5 @@
 from subprocess import Popen, PIPE
+
 # Python<=3.8 don't support typing with builtin dict.
 from typing import Dict
 
@@ -12,7 +13,9 @@ _MTIMES_STASH_KEY = pytest.StashKey[Dict[str, float]]()
 def pytest_addoption(parser):
     group = parser.getgroup("general")
     group.addoption("--ruff", action="store_true", help="enable checking with ruff")
-    group.addoption("--ruff-format", action="store_true", help="enable format checking with ruff")
+    group.addoption(
+        "--ruff-format", action="store_true", help="enable format checking with ruff"
+    )
 
 
 def pytest_configure(config):
@@ -63,7 +66,7 @@ class RuffFile(pytest.File):
 
 def check_file(self, path):
     ruff = find_ruff_bin()
-    command = [ruff, "check", path, '--quiet', '--show-source', '--force-exclude']
+    command = [ruff, "check", path, "--quiet", "--show-source", "--force-exclude"]
     child = Popen(command, stdout=PIPE, stderr=PIPE)
     stdout, _ = child.communicate()
     if stdout:
@@ -72,7 +75,7 @@ def check_file(self, path):
 
 def format_file(self, path):
     ruff = find_ruff_bin()
-    command = [ruff, "format", path, '--quiet', '--check', '--force-exclude']
+    command = [ruff, "format", path, "--quiet", "--check", "--force-exclude"]
     with Popen(command) as child:
         pass
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import pytest
 
 import pytest_ruff
@@ -27,9 +30,51 @@ def test_configure_without_ruff(mocker):
 
 def test_check_file():
     with pytest.raises(pytest_ruff.RuffError, match=r"`os` imported but unused"):
-        pytest_ruff.check_file("tests/assets/check_broken.py")
+        pytest_ruff.check_file(None, path="tests/assets/check_broken.py")
 
 
 def test_format_file():
     with pytest.raises(pytest_ruff.RuffError, match=r"File would be reformatted"):
-        pytest_ruff.format_file("tests/assets/format_broken.py")
+        pytest_ruff.format_file(None, path="tests/assets/format_broken.py")
+
+
+def test_pytest_ruff():
+    out, err = subprocess.Popen(
+        [sys.executable, "-m", "pytest", "--ruff", "tests/assets/check_broken.py"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).communicate()
+    out_utf8 = out.decode("utf-8")
+    assert "`os` imported but unused" in out_utf8
+    assert "force-exclude:1:1: E902 No such file or directory (os error 2)" not in out_utf8
+
+
+def test_pytest_ruff_format():
+    out, err = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--ruff",
+            "--ruff-format",
+            "tests/assets/format_broken.py",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).communicate()
+    assert "File would be reformatted" in out.decode("utf-8")
+
+
+def test_pytest_ruff_noformat():
+    out, err = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--ruff",
+            "tests/assets/format_broken.py",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).communicate()
+    assert "File would be reformatted" not in out.decode("utf-8")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -30,12 +30,12 @@ def test_configure_without_ruff(mocker):
 
 def test_check_file():
     with pytest.raises(pytest_ruff.RuffError, match=r"`os` imported but unused"):
-        pytest_ruff.check_file(None, path="tests/assets/check_broken.py")
+        pytest_ruff.check_file("tests/assets/check_broken.py")
 
 
 def test_format_file():
     with pytest.raises(pytest_ruff.RuffError, match=r"File would be reformatted"):
-        pytest_ruff.format_file(None, path="tests/assets/format_broken.py")
+        pytest_ruff.format_file("tests/assets/format_broken.py")
 
 
 def test_pytest_ruff():
@@ -46,9 +46,6 @@ def test_pytest_ruff():
     ).communicate()
     out_utf8 = out.decode("utf-8")
     assert "`os` imported but unused" in out_utf8
-    assert (
-        "force-exclude:1:1: E902 No such file or directory (os error 2)" not in out_utf8
-    )
 
 
 def test_pytest_ruff_format():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -46,7 +46,9 @@ def test_pytest_ruff():
     ).communicate()
     out_utf8 = out.decode("utf-8")
     assert "`os` imported but unused" in out_utf8
-    assert "force-exclude:1:1: E902 No such file or directory (os error 2)" not in out_utf8
+    assert (
+        "force-exclude:1:1: E902 No such file or directory (os error 2)" not in out_utf8
+    )
 
 
 def test_pytest_ruff_format():


### PR DESCRIPTION
fixes https://github.com/businho/pytest-ruff/issues/7 and #9 

TODO
- [ ] fix test case `test_pytest_ruff_noformat` where `--ruff` is specified but not `--ruff-format`