### PR TITLE
fix: pytest 8.1 compat

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{38,39,310,311,312}-pytest{5,6,7,8},lint
+envlist = py{38,39,310,311,312}-pytest{5,6,7,8,810,81},lint
 
 [testenv]
 allowlist_externals = poetry
@@ -9,7 +9,10 @@ commands =
     pytest5: pip install "pytest<6"
     pytest6: pip install "pytest>=6,<7"
     pytest7: pip install "pytest>=7,<8"
-    pytest8: pip install "pytest>=8,<9"
+    pytest8: pip install "pytest>=8,<8.1"
+    # pytest 8.1.0 was yanked, but their "broken behaviour" will comeback soon
+    pytest810: pip install "pytest==8.1.0"
+    pytest81: pip install "pytest>=8.1,<9"
     # Disable ruff plugin to generate better coverage results
     poetry run pytest -p no:ruff -vvv --cov --cov-append --cov-report term --cov-report xml {posargs}
 


### PR DESCRIPTION
Updates the `pytest_collect_file` hook to conform to the new call syntax while still providing the old syntax for backwards compat with pytest < 7.0.0.

* Fixes #15 
* heavily ~~stolen from~~ inspired by https://github.com/astropy/pytest-filter-subpackage/pull/15
* See also https://github.com/pytest-dev/pytest/issues/11779
* API ref: https://docs.pytest.org/en/8.0.x/reference/reference.html#std-hook-pytest_collect_file

## Further notes

The pytest api docs still mention that the deprecated `path` param still works but it was removed in 8.1 completely (https://github.com/pytest-dev/pytest/pull/11757) and the docs will mention it being gone since 8.0.0 once the 8.1.x docs are released.

Given the new param was introduced all the way back in 7.0.0, this patch uses it starting from that version. Hopefully this will make removing this, rather kludgy, compat implementation once it isn't needed anymore easier.