### PR TITLE
Handle ruff config error

### DIFF
--- a/pytest_ruff/__init__.py
+++ b/pytest_ruff/__init__.py
@@ -95,9 +95,13 @@ def check_file(path):
         "--force-exclude",
     ]
     child = Popen(command, stdout=PIPE, stderr=PIPE)
-    stdout, _ = child.communicate()
-    if stdout:
+    stdout, stderr = child.communicate()
+
+    if child.returncode == 1:
         raise RuffError(stdout.decode())
+
+    if child.returncode == 2:
+        raise RuffError(stderr.decode())
 
 
 def format_file(path):
@@ -108,6 +112,9 @@ def format_file(path):
 
     if child.returncode == 1:
         raise RuffError("File would be reformatted")
+
+    if child.returncode == 2:
+        raise RuffError("Ruff terminated abnormally")
 
 
 def pytest_exception_interact(node, call, report):

--- a/tests/assets/broken_config/empty.py
+++ b/tests/assets/broken_config/empty.py
@@ -1,0 +1,1 @@
+# Empty file to try to run ruff, but config in ruff.toml is broken.

--- a/tests/assets/broken_config/ruff.toml
+++ b/tests/assets/broken_config/ruff.toml
@@ -1,0 +1,1 @@
+broken = true

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -79,3 +79,20 @@ def test_pytest_ruff_noformat():
     ).communicate()
     assert err.decode() == ""
     assert "File would be reformatted" not in out.decode("utf-8")
+
+
+def test_broken_ruff_config():
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--ruff",
+            "tests/assets/broken_config/empty.py",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = process.communicate()
+    assert err.decode() == ""
+    assert "unknown field `broken`" in out.decode()


### PR DESCRIPTION
Fix #22.

Tests should fail if ruff config is broken.
