### PR TITLE
Add argument to use custom configuration

### DIFF
--- a/tests/assets/long_line.py
+++ b/tests/assets/long_line.py
@@ -1,0 +1,2 @@
+# File with just 1 value that conforms to the override config file but breaks the default
+a = "This is a very long string that goes over the default number of characters, " + "but according to the config override should be fine"

--- a/tests/assets/long_line_config/ruff.toml
+++ b/tests/assets/long_line_config/ruff.toml
@@ -1,0 +1,2 @@
+# longer than the default at the project root
+line-length = 140

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -98,6 +98,43 @@ def test_broken_ruff_config():
     assert "unknown field `broken`" in out.decode()
 
 
+def test_custom_ruff_config():
+    # fails with default
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--ruff",
+            "--ruff-format",
+            "tests/assets/long_line.py",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = process.communicate()
+    assert err.decode() == ""
+    assert "File would be reformatted" in out.decode("utf-8")
+
+    # succeeds with custom
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--ruff",
+            "--ruff-format",
+            "--ruff-config=tests/assets/long_line_config/ruff.toml",
+            "tests/assets/long_line.py",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = process.communicate()
+    assert err.decode() == ""
+    assert "tests/assets/long_line.py ." in out.decode()
+
+
 def test_without_pytest_cache():
     process = subprocess.Popen(
         [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -30,12 +30,12 @@ def test_configure_without_ruff(mocker):
 
 def test_check_file():
     with pytest.raises(pytest_ruff.RuffError, match=r"`os` imported but unused"):
-        pytest_ruff.check_file("tests/assets/check_broken.py")
+        pytest_ruff.check_file("tests/assets/check_broken.py", None)
 
 
 def test_format_file():
     with pytest.raises(pytest_ruff.RuffError, match=r"File would be reformatted"):
-        pytest_ruff.format_file("tests/assets/format_broken.py")
+        pytest_ruff.format_file("tests/assets/format_broken.py", None)
 
 
 def test_pytest_ruff():


### PR DESCRIPTION
First of all, thanks for building this plugin, I've found it very useful!

Currently I am working on a monorepo setup, which means I work with a hierarchy of folders with different packages. In order to keep some consistency, it'd be great if I could parametrise the input config for the plugin, which is what I am attempting to do in this PR.

I took some inspiration from [`pytest-mypy`](https://github.com/realpython/pytest-mypy) to build the way the config is injected into the plugin.

Hope this makes sense, let me know if you'd prefer to do it in a different way!